### PR TITLE
added support for br tags on input

### DIFF
--- a/js/texteditor.js
+++ b/js/texteditor.js
@@ -7,7 +7,7 @@ oT.texteditor = {}
 oT.texteditor.clean = function( html ){
     var result = $.htmlClean(html, {
         format: false,
-        allowedTags: ['p', 'div', 'strong', 'em', 'i', 'b', 'span'],
+        allowedTags: ['p', 'div', 'strong', 'em', 'i', 'b', 'span', 'br'],
         allowedAttributes: [['class',['span']],['data-timestamp',['span']]],
         allowedClasses: ['timestamp']
     });


### PR DESCRIPTION
As per twitter convo yesterday, simply adding the 'br' tag to the texteditor allowed list to render <br> tags appropriately when importing from .otr