### PR TITLE
fix chromebook keybindings

### DIFF
--- a/js/other.js
+++ b/js/other.js
@@ -88,22 +88,22 @@ function chromeOsCheck(){
         
         Mousetrap.bind('ctrl+1', function(e) {
             pd(e);
-            skip('backwards');
+            oT.player.skip('backwards');
             return false;
         });
         Mousetrap.bind('ctrl+2', function(e) {
             pd(e);
-            skip('forwards');
+            oT.player.skip('forwards');
             return false;
         });
         Mousetrap.bind('ctrl+3', function(e) {
             pd(e);
-            speed('down');
+            oT.player.speed('down');
             return false;
         });
         Mousetrap.bind('ctrl+4', function(e) {
             pd(e);
-            speed('up');
+            oT.player.speed('up');
             return false;
         });
     }


### PR DESCRIPTION
'skip' and 'speed' were undefined so the Ctrl+1,2,3,4 weren't working. 

FWIW, on my Chromebook, the search key (Super) actually modifies both the top row *and* number row of keys to be function keys, so doing Search+1,2,3,4 worked until I figured out the issue.