### PR TITLE
Fix cancel button bug

### DIFF
--- a/src/js/app/settings/KeyboardShortcuts.jsx
+++ b/src/js/app/settings/KeyboardShortcuts.jsx
@@ -26,6 +26,9 @@ class Shortcut extends Component {
         const removeCombo = function(keyFn, index) {
             keyCombos.splice(index, 1)
             onChange(keyFn, keyCombos);
+            this.setState({
+                listening: false
+            });
         };
         const combos = keyCombos.map((combo, i) => (
             <span className="key-combo">
@@ -45,12 +48,18 @@ class Shortcut extends Component {
                 </span>
             ));
         } else {
-            combos.push((
-                <span
-                    className={`add-combo`}
-                    onClick={listenForShortcut.bind(this, keyFn)}
-                >+</span>
-            ));
+            if (this.state.listening == undefined) {
+              combos.push((
+                  <span
+                      className={`add-combo`}
+                      onClick={listenForShortcut.bind(this, keyFn)}
+                  >+</span>
+              ));
+            } else {
+              this.setState({
+                  listening: undefined
+              });
+            }
         }
         return (
             <li>


### PR DESCRIPTION
This is to fix https://github.com/oTranscribe/oTranscribe/issues/80. Reading the Issue it does seem like the browsers might be handling rendering differently? On Chrome what seems to be happening is that the render function is called twice and the click event is processed twice thus if a user clicks 'cancel', the `+`-button is readded and it thinks it was clicked directly. Also if a shortcut is removed, the same thing happens, the rendering is triggered and a click on the `+`-button is registered.

I've spent a few hours over the past three days looking into this but I don't think I can get any further. What I've implemented here is a workaround that fixes it for chrome. I have not tested this on Firefox. This almost certainly isn't the right way to fix this. 

If you know a way we could identify/differentiate the clicks better to avoid this issue, that would help. I'm kind of hoping you might see the solution with this. 