### PR TITLE
Update privacy.htm to fix typo

### DIFF
--- a/src/privacy.htm
+++ b/src/privacy.htm
@@ -23,7 +23,7 @@
 
         <p><strong>What We Collect and How We Use the Information We Collect</strong></p>
 
-        <p>We do not <b>not</b> store copies of your transcripts nor your audio or video files that you are currently transcribing.</p>
+        <p>We do <strong>not</strong> store copies of your transcripts nor your audio or video files that you are currently transcribing.</p>
 
         <p>As part of the services provided by oTranscribe, we may collect some &quot;Personally Identifiable Information,&quot; such as your first name, last name, and e-mail address. You may optionally supply other information that can be used to contact you or identify you as an individual, including your postal address and phone number (collectively, “Optional Personally Identifiable Information”). We use Personally Identifiable Information and Optional Personally Identifiable Information to communicate with you and to assist in processing and managing your support requests (for example, when you email us with a question). If you make a donation or register for a mailing list, we may also require you to set up an account and, at that time, oTranscribe will collect your username, user ID number, and a hashed password. </p>
 


### PR DESCRIPTION
I assume that the line about storing copies of transcripts contains a typo, and propose a fix here. Should this be intended, then I'd propose to use a positive connotation for the sentence. (e. g. "We do store copies...". Furthermore, <b> doesn't seem to work on your page, probably related to the CSS.